### PR TITLE
Fix scene change

### DIFF
--- a/Dareka_Somebody/Assets/Scenes/SampleScene.unity.meta
+++ b/Dareka_Somebody/Assets/Scenes/SampleScene.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 92e0e35150638468caa53edf8ace92e4
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Dareka_Somebody/Assets/Scenes/StageScene.unity
+++ b/Dareka_Somebody/Assets/Scenes/StageScene.unity
@@ -291,11 +291,11 @@ RectTransform:
   m_Children:
   - {fileID: 788755890}
   m_Father: {fileID: 1655027052}
-  m_RootOrder: 2
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 30}
+  m_AnchoredPosition: {x: -300, y: 30}
   m_SizeDelta: {x: 160, y: 96.5395}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &468944961
@@ -344,7 +344,7 @@ MonoBehaviour:
       m_Calls:
       - m_Target: {fileID: 1220097415}
         m_TargetAssemblyTypeName: SceneControl, Assembly-CSharp
-        m_MethodName: OnclickSelectStage
+        m_MethodName: OnclickSelectStage_Setsubun
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -885,8 +885,8 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 531198506}
-  - {fileID: 2047414623}
   - {fileID: 468944960}
+  - {fileID: 2047414623}
   - {fileID: 1791762026}
   m_Father: {fileID: 0}
   m_RootOrder: 2
@@ -977,7 +977,7 @@ GameObject:
   - component: {fileID: 1791762028}
   - component: {fileID: 1791762027}
   m_Layer: 5
-  m_Name: Seizinsiki
+  m_Name: SeijinnoHi
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -1050,7 +1050,7 @@ MonoBehaviour:
       m_Calls:
       - m_Target: {fileID: 1220097415}
         m_TargetAssemblyTypeName: SceneControl, Assembly-CSharp
-        m_MethodName: OnclickSelectStage
+        m_MethodName: OnclickSelectStage_SeijinnoHi
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -1266,11 +1266,11 @@ RectTransform:
   m_Children:
   - {fileID: 1844593051}
   m_Father: {fileID: 1655027052}
-  m_RootOrder: 1
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -300, y: 30}
+  m_AnchoredPosition: {x: 0, y: 30}
   m_SizeDelta: {x: 160, y: 96.5395}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &2047414624
@@ -1319,7 +1319,7 @@ MonoBehaviour:
       m_Calls:
       - m_Target: {fileID: 1220097415}
         m_TargetAssemblyTypeName: SceneControl, Assembly-CSharp
-        m_MethodName: OnclickSelectStage
+        m_MethodName: "OnclickSelectStage_Osh\u014Dgatsu"
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}

--- a/Dareka_Somebody/Assets/Scenes/TitleScene.unity
+++ b/Dareka_Somebody/Assets/Scenes/TitleScene.unity
@@ -446,8 +446,8 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 770084039}
-        m_TargetAssemblyTypeName: TitleDirector, Assembly-CSharp
-        m_MethodName: OnclickNewGame
+        m_TargetAssemblyTypeName: SceneControl, Assembly-CSharp
+        m_MethodName: OnclickStageScene
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}

--- a/Dareka_Somebody/Assets/Scripts/SceneControl.cs
+++ b/Dareka_Somebody/Assets/Scripts/SceneControl.cs
@@ -15,18 +15,30 @@ public class SceneControl : MonoBehaviour
     SceneCounter = PlayerPrefs.GetInt("CurrentScene");
     */
 
-    public void OnclickNewGame()
+    public void OnclickStageScene()
     {
-        Debug.Log("New Game");
-        SceneManager.LoadScene("StageScene");
+        Debug.Log("Loading Stage Scene");
+        SceneManager.LoadScene(1);
+    }
+    //pause - menu
+
+    public void OnclickSelectStage_Setsubun()
+    {
+        Debug.Log("Loading Setsubun Scene");
+        //SceneManager.LoadScene();
     }
 
-    public void OnclickSelectStage()
+    public void OnclickSelectStage_Oshōgatsu()
     {
-        //Debug.Log("Loading Scene No." + Scene number);
-        SceneManager.LoadScene("House");
-        //SceneManager.LoadScene(scene name will be changed into scene number)
-    }    
+        Debug.Log("Loading Oshogatsu Scene");
+        SceneManager.LoadScene(2);
+    }
+
+    public void OnclickSelectStage_SeijinnoHi()
+    {
+        Debug.Log("Loading SeijinnoHi Scene");
+        //SceneManager.LoadScene();
+    }
 
     public void OnclickQuitGame()
     {

--- a/Dareka_Somebody/ProjectSettings/EditorBuildSettings.asset
+++ b/Dareka_Somebody/ProjectSettings/EditorBuildSettings.asset
@@ -8,4 +8,10 @@ EditorBuildSettings:
   - enabled: 1
     path: Assets/Scenes/TitleScene.unity
     guid: 2b26338cc57d8c94f9bc558d794eea5e
+  - enabled: 1
+    path: Assets/Scenes/StageScene.unity
+    guid: 2bb4f19f99cc9494b95bfc94d04bc5b3
+  - enabled: 1
+    path: Assets/Scenes/House/House.unity
+    guid: 6395e6dd8ec19ba47a5da4b7731b54b3
   m_configObjects: {}


### PR DESCRIPTION
StageScene 스테이지 순서 변경
-----------------------------------

* 스토리 수정에 따라 스테이지 순서를 세츠분 -> 오쇼가츠 -> 성인의 날로 변경했습니다. 



SceneControl script 수정
-----------------------------
* OnclickSelectStage_스테이지 이름으로 함수 3개를 추가하여 각각의 스테이지 버튼 클릭 시 해당 스테이지에 해당하는 인덱스의 씬으로 전환되도록 하였습니다. (현재는 오쇼가츠 버튼 -> House 씬으로 전환 상태)

* OnclickNewGame()을 OnclickStageScene()으로 수정하여 게임 시작 때 stage 씬으로 들어가는 것뿐만 아니라 이후 esc 메뉴 추가 시 메뉴에서 stage 씬으로 돌아가는 것을 해당 함수로 처리할 수 있도록 하였습니다. 